### PR TITLE
Remove the max-width from imgs within map canvases.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,3 +28,7 @@ body {
   height: 400px;
   width: 40%;
 }
+
+.map-canvas img {
+  max-width: none;
+}

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Trail Reporter</h1>
-<div id="map-home-canvas"></div>
+<div id="map-home-canvas" class="map-canvas"></div>
 
 <p id="current-coordinates">
   locating...

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,5 +1,5 @@
 <h1>New report</h1>
-<div id="map-canvas"></div>
+<div id="map-canvas" class="map-canvas"></div>
 <%= render 'form' %>
 
 <%= link_to 'Back', reports_path %>


### PR DESCRIPTION
Google maps uses a large sprite image. Bootstrap puts `max-width: 100%` on images by default, which causes the sprite image to be resized inappropriately.

This just removes the `max-width` from `<img>`s within map canvases.
